### PR TITLE
Revert to OpenGL 3.3 core for all platforms

### DIFF
--- a/src/something_main.cpp
+++ b/src/something_main.cpp
@@ -65,8 +65,8 @@ int main(int argc, char *argv[])
     defer(SDL_DestroyWindow(window));
 
     {
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
         SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
         int major;


### PR DESCRIPTION
Close #56 

Since OpenGL 3.3 is the lowest common denominator, let's use that instead. It also works on macOS.