### PR TITLE
[config_indexer] Update baked index generation

### DIFF
--- a/src/config_indexer.cpp
+++ b/src/config_indexer.cpp
@@ -97,10 +97,9 @@ int main(int argc, char **argv)
     println(stdout);
     if (bake) {
         for (size_t i = 0; i < config_defs.size; ++i) {
-            print(stdout, "#define ", config_defs[i].name, " ");
             switch (config_defs[i].type) {
             case Config_Type::Float:
-                println(stdout, config_values[i].as_float);
+                println(stdout, "const float ", config_defs[i].name, " = ", config_values[i].as_float, ";");
                 break;
             default:
                 unreachable("baked config_values macros");


### PR DESCRIPTION
Generate baked index as a collection of C++ const values instead of C
macros. This makes the semantics of the baked and unbaked versions of
the index a bit closer to each other