### PR TITLE
msys2 --release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,17 @@ jobs:
         run: |
           msys2 -c 'pacman --noconfirm -Suuy'
           msys2 -c 'pacman --noconfirm -Suu'
-      - name: Build
+      - name: debug build
         run: |
           build_msys2.bat
+        shell: cmd
+        env:
+          CC: gcc
+          CXX: g++
+          PATH: D:\a\_temp\msys\msys64\usr\bin;D:\a\_temp\msys\msys64\${{ matrix.msystem_lower }}\bin;D:\a\_temp\msys
+      - name: release build
+        run: |
+          build_msys2.bat --release
         shell: cmd
         env:
           CC: gcc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
-          install: mingw-w64-${{ matrix.arch }}-toolchain mingw-w64-${{ matrix.arch }}-SDL2 mingw-w64-${{ matrix.arch }}-glew mingw-w64-${{ matrix.arch }}-pkg-config
+          install: mingw-w64-${{ matrix.arch }}-gcc mingw-w64-${{ matrix.arch }}-SDL2 mingw-w64-${{ matrix.arch }}-glew mingw-w64-${{ matrix.arch }}-pkg-config
           update: true
       - name: Update
         run: |

--- a/build_msys2.bat
+++ b/build_msys2.bat
@@ -10,10 +10,13 @@ set /p PKGLIBS=<temp.txt
 del temp.txt
 
 %CXX% %CXXFLAGS% -o config_indexer.exe src/config_indexer.cpp
-config_indexer assets/vars.conf >src/config_index.hpp
 
-%CXX% %CXXFLAGS% %PKGSCFLAGS% -o something.debug.exe src/something.cpp %PKGLIBS% -lopengl32 -static
+if "%~1"=="--release" (
+    config_indexer --bake assets/vars.conf >src/config_index.hpp
+    %CXX% %CXXFLAGS% -O3 %PKGSCFLAGS% -DSOMETHING_RELEASE -o something.release.exe src/something.cpp %PKGLIBS% -lopengl32 -static
+) else (
+    config_indexer assets/vars.conf >src/config_index.hpp
+    %CXX% %CXXFLAGS% %PKGSCFLAGS% -o something.debug.exe src/something.cpp %PKGLIBS% -lopengl32 -static
+)
 
 dir *.exe
-
-rem TODO(#73): no release build on CI for msys2

--- a/build_msys2.bat
+++ b/build_msys2.bat
@@ -11,12 +11,23 @@ del temp.txt
 
 %CXX% %CXXFLAGS% -o config_indexer.exe src/config_indexer.cpp
 
-if "%~1"=="--release" (
+setlocal
+for %%i in (%*) do (
+    if "%%i" == "--release" (
+        set SOMETHING_RELEASE=1
+    ) else (
+        echo ERROR: Unknown flag "%%i"
+        goto :eof
+    )
+)
+
+if defined SOMETHING_RELEASE (
     config_indexer --bake assets/vars.conf >src/config_index.hpp
     %CXX% %CXXFLAGS% -O3 %PKGSCFLAGS% -DSOMETHING_RELEASE -o something.release.exe src/something.cpp %PKGLIBS% -lopengl32 -static
 ) else (
     config_indexer assets/vars.conf >src/config_index.hpp
     %CXX% %CXXFLAGS% %PKGSCFLAGS% -o something.debug.exe src/something.cpp %PKGLIBS% -lopengl32 -static
 )
+endlocal
 
 dir *.exe


### PR DESCRIPTION
closes #73 
also replaced [toolchain package](https://packages.msys2.org/group/mingw-w64-x86_64-toolchain) with just gcc, improving CI times